### PR TITLE
:ambulance: Fix avatar not being shown

### DIFF
--- a/src/Cards/src/components/card.story.tsx
+++ b/src/Cards/src/components/card.story.tsx
@@ -37,7 +37,10 @@ const CardStory = () => pipe(
                     data.avatar,
                     O.fold(
                         () => RemoteImageAdt.of.NotLoaded({}),
-                        url => RemoteImageAdt.of.Loaded({ url }),
+                        remoteUrl => RemoteImageAdt.of.Loaded({
+                            remoteUrl,
+                            objectUrl: remoteUrl
+                        }),
                     ),
                 )}
             />

--- a/src/Cards/src/components/card.tsx
+++ b/src/Cards/src/components/card.tsx
@@ -31,16 +31,17 @@ export const Card: FunctionComponent<CardProps> = ({
 
             {pipe(
                 avatar,
-                // TODO Loading animation for Avatar
-                O.fromPredicate(RemoteImageAdt.is.Loaded),
-                O.fold(
-                    Empty,
-                    ({ url }) => <div className={styles.layoutNarrow}>
-                        <div className={styles.avatarCircle}>
-                            <img src={url} className={styles.avatar} />
-                        </div>
-                    </div>
-                )
+                RemoteImageAdt.match({
+                    NotLoaded: Empty,
+                    // TODO: Loading animation for avatar
+                    Loading: Empty,
+                    Loaded: ({ objectUrl }) => <div className={styles.layoutNarrow}>
+                        <Avatar url={objectUrl} />
+                    </div>,
+                    Failure: ({ error }) => <div className={styles.layoutNarrow}>
+                        <Avatar url={error.remoteUrl} />
+                    </div>,
+                })
             )}
 
             {pipe(
@@ -160,4 +161,14 @@ const Details: FunctionComponent<DetailProps> = ({
             )}
         </ul>
     </address>
+);
+
+type AvatarProps = {
+    url: string;
+};
+
+const Avatar: FunctionComponent<AvatarProps> = ({ url }) => (
+    <div className={styles.avatarCircle}>
+        <img src={url} className={styles.avatar} />
+    </div>
 );


### PR DESCRIPTION
With the addition of the avatar image to the vCard file, image handling was moved away from classic `<img>` to `fetch`. It was done to be able to read image data, encode it to vCard and wite it to vCard.

Problem wit fetch is CORS. If no CORS headers were set by the server serving the image, the image could not be downloaded any more. This is not a problem with `<img>`, but then we cannot access the images data anymore.

So the solution here is to still use fetch. In case it works we can write vCard data and show the avatar from fetch result. In case it does not work, we at least show the avatar using `<img>` but won't write the avatar to the vCard.