### PR TITLE
:bug: Force light mode for QR Code

### DIFF
--- a/src/Cards/src/components/qr-code-card.tsx
+++ b/src/Cards/src/components/qr-code-card.tsx
@@ -1,4 +1,5 @@
 import * as styles from "./qr-code-card.css";
+import * as theme from "../theme/variables.css";
 
 import type { FunctionComponent } from "preact";
 import { PageContent } from "./page-content";
@@ -16,7 +17,7 @@ export const QrCodeCard: FunctionComponent<QrCodeCardProps> = ({
     <PageContent className={className}>
         <QrCode text={href}
             border={5}
-            className={styles.qrCode}
+            className={`${styles.qrCode} ${theme.lightTheme}`}
         />
     </PageContent>
 );

--- a/src/Cards/src/theme/variables.css.ts
+++ b/src/Cards/src/theme/variables.css.ts
@@ -114,3 +114,13 @@ export const defaultTheme = style({
         },
     },
 });
+
+export const lightTheme = style({
+    vars: lightThemeVars,
+
+    "@media": {
+        "(prefers-color-scheme: dark)": {
+            vars: lightThemeVars,
+        },
+    },
+});


### PR DESCRIPTION
QR Code is always shown black on white now. 

Fix for #28 