### PR TITLE
:bug: Fix bottom bar not visible on mobile

### DIFF
--- a/src/Cards/index.html
+++ b/src/Cards/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-    <div id="app"></div>
+    <div id="app" class="app-container"></div>
     <script type="module"
         src="/src/main.tsx"></script>
 </body>

--- a/src/Cards/src/components/app.css.ts
+++ b/src/Cards/src/components/app.css.ts
@@ -5,7 +5,7 @@ import { varsApp } from "../theme/variables.css";
 export const CssVarBackground = createVar();
 
 export const app = style({
-    height: "100vh",
+    height: "100%",
     width: "100vw",
 
     backgroundSize: "cover",

--- a/src/Cards/src/components/page.tsx
+++ b/src/Cards/src/components/page.tsx
@@ -30,7 +30,7 @@ export const Page: FunctionComponent<PageProps> = ({
 const translateFitToCss = (fit: FitHeightTypes) => {
     switch (fit) {
         case "content": return "fit-content";
-        case "screen": return "100vh";
+        case "screen": return "100%";
 
         default: return absurd<FitHeightTypes>(fit);
     }

--- a/src/Cards/src/styles/base.css
+++ b/src/Cards/src/styles/base.css
@@ -1,7 +1,8 @@
 body,
 html {
     overscroll-behavior: none;
-    min-height: 100vh;
+    height: 100%;
+    min-height: 100%;
 
     overflow: hidden;
 
@@ -27,4 +28,8 @@ body {
 /* cancel reset */
 a[href] {
     cursor: pointer;
+}
+
+.app-container {
+    height: 100%;
 }


### PR DESCRIPTION
This works by replacing heights of 100vh with 100%. VH on mobile does not take browser ui into account, making browser ui overlap the site. What's more is, it's done on purpose 🤦‍♂️.
Newer viewport unit dvh is supposed to fix this, but is not supported broadly yet.